### PR TITLE
Update firestore_converter_generator.dart

### DIFF
--- a/packages/firestore_converter_generator/lib/firestore_converter_generator.dart
+++ b/packages/firestore_converter_generator/lib/firestore_converter_generator.dart
@@ -4,7 +4,7 @@ import 'package:firestore_converter/firestore_converter.dart';
 import 'package:source_gen/source_gen.dart';
 
 Builder firestoreConverterGeneratorFactory(BuilderOptions options) =>
-    PartBuilder([FirestoreConverterGenerator()], '.firestore_converter.dart');
+    PartBuilder([FirestoreConverterGenerator()], '.firestore_converter.dart', options: options);
 
 class FirestoreConverterGenerator
     extends GeneratorForAnnotation<FirestoreConverter> {


### PR DESCRIPTION
Update the builder to use build.yaml options. These options include the ability to update build_extensions so the generated files can be placed into a different directory. 

build.yaml
```

targets:
  $default:
    builders:
      source_gen|combining_builder:
        options:
          ignore_for_file:
            - implicit_dynamic_parameter
          build_extensions: {'lib/src/models/{{}}.dart': ['lib/src/models/generated/{{}}.g.dart']}
      firestore_converter_generator:
        enabled: true
        options: 
          build_extensions: {'lib/src/models/{{}}.dart': ['lib/src/models/generated/{{}}.firestore_converter.dart']}
```